### PR TITLE
Adds support for '# -' and '# |'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ py2nb: convert python scripts to jupyter notebooks
 ==================================================
 :py2nb: convert python scripts to jupyter notebooks
 :Author: Will Handley
-:Version: 0.0.4
+:Version: 1.0.0
 :Homepage: https://github.com/williamjameshandley/py2nb
 
 .. image:: https://badge.fury.io/py/py2nb.svg
@@ -14,7 +14,7 @@ Description
 ===========
 
 ``py2nb`` is a python package for converting python scripts with minimal
-markdown to jupyter notebooks. 
+markdown to jupyter notebooks.
 
 Markdown cells are rendered from comments beginning with ``#|``, splits between
 code cells are created by comment lines beginning with ``#-``
@@ -49,44 +49,56 @@ If one has a script named ``example.py`` containing the code:
 
 .. code:: python
 
-   #| # Testing ipython notebook
-   #| This is designed to demonstrate a simple script that converts a script into
-   #| a jupyter notebook with a simple additional markdown format.
-   #|
-   #| Code by default will be put into code cells
-   #|
-   #| * To make a markdown cell, prefix the comment line with with '#|'
-   #| * To split a code cell, add a line beginning with '#-'
-   
-   import numpy
-   import matplotlib.pyplot as plt
-   %matplotlib inline
-   
-   #| Here is a markdown cell.
-   #| Maths is also possible: $A=B$
-   #|
-   #| There are code cells below, split by '#-':
-   
-   x = numpy.random.rand(5)
-   
-   #-------------------------------
-   
-   y = numpy.random.rand(4)
-   z = numpy.random.rand(3)
-   
-   #| Here are some plots
-   
-   x = numpy.linspace(-2,2,1000)
-   y = x**3
-   fig, ax = plt.subplots()
-   ax.plot(x,y)
+    #| # Testing ipython notebook
+    #| This is designed to demonstrate a simple script that converts a script into
+    #| a jupyter notebook with a simple additional markdown format.
+    #|
+    #| Code by default will be put into code cells
+    #|
+    #| * To make a markdown cell, prefix the comment line with with '#|' or '# |'
+    #| * To split a code cell, add a line beginning with '#-' or '# -'
+
+    import matplotlib.pyplot as plt
+    import numpy
+
+    %matplotlib inline
+
+    #| Here is a markdown cell.
+    #| Maths is also possible: $A=B$
+    #|
+    #| There are code cells below, split by `'#-'`:
+
+    # | Here is another markdown cell
+
+    x = numpy.random.rand(5)
+
+    #-------------------------------
+
+    y = numpy.random.rand(4)
+    z = numpy.random.rand(3)
+
+    #| Here are some plots
+
+    x = numpy.linspace(-2,2,1000)
+    y = x**3
+    fig, ax = plt.subplots()
+    ax.plot(x,y)
+
+    # -------------------------------
+
+    # | Here is another plot
+
+    x = np.linspace(-np.pi, np.pi, 201)
+    fig, ax = plt.subplots()
+    ax.plot(x,np.sin(x))
+
 
 then running
 
 .. code :: bash
-   
+
    py2nb example.py
-   
+
 produces the notebook `example.ipynb <https://github.com/williamjameshandley/py2nb/blob/master/example.ipynb>`_
 
 To do

--- a/example.ipynb
+++ b/example.ipynb
@@ -11,7 +11,7 @@
     " Code by default will be put into code cells\n",
     "\n",
     " * To make a markdown cell, prefix the comment line with with '#|' or '# |'\n",
-    " * To split a code cell, add a line beginning with '#-' or '# -#"
+    " * To split a code cell, add a line beginning with '#-' or '# -'"
    ]
   },
   {
@@ -100,25 +100,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.7"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/example.ipynb
+++ b/example.ipynb
@@ -9,19 +9,20 @@
     " a jupyter notebook with a simple additional markdown format.\n",
     "\n",
     " Code by default will be put into code cells\n",
-    " \n",
-    " * To make a markdown cell, prefix the comment line with with '#|'\n",
-    " * To split a code cell, add a line beginning with '#-'"
+    "\n",
+    " * To make a markdown cell, prefix the comment line with with '#|' or '# |'\n",
+    " * To split a code cell, add a line beginning with '#-' or '# -#"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy\n",
+    "\n",
     "%matplotlib inline"
    ]
   },
@@ -32,12 +33,19 @@
     "Here is a markdown cell.\n",
     " Maths is also possible: $A=B$\n",
     "\n",
-    " There are code cells below, split by '#-':"
+    " There are code cells below, split by `'#-'`:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is another markdown cell"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,37 +71,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7fbd3574c710>]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvDW2N/gAAIABJREFUeJzt3Xl4VOX9/vH3JzuBhLCDCQHZBWQNiGhdEam7dSlVrLa2VFurttpWpa12+X6/olWr1WqpS9WquOHWKosiVloFwk4gEHbClkAgCYSs8/z+yMCPYoCEOZMzmdyv6+LKJHPynDsn4c7JM2cx5xwiIhI9YvwOICIi3lKxi4hEGRW7iEiUUbGLiEQZFbuISJRRsYuIRBkVu4hIlFGxi4hEGRW7iEiUifNjpe3bt3fdu3f3Y9UiIk3WwoULdznnOhxvOV+KvXv37mRnZ/uxahGRJsvMNtVnOU3FiIhEGRW7iEiUUbGLiEQZFbuISJRRsYuIRBlPit3MfmJmOWa2wsxeM7MkL8YVEZGGC7nYzSwduB3Ics4NBGKB8aGOKyIiJ8arqZg4oIWZxQHJwDaPxhURiQrlVTU88H4OW/ceCPu6Qi5259xW4A/AZmA7UOycm3nkcmY20cyyzSy7sLAw1NWKiDQpL3+xib/9ZyP5RWVhX5cXUzFtgMuBk4GTgJZmNuHI5ZxzU5xzWc65rA4djntGrIhI1Cgtr+LPc9bytd7tOa1Hu7Cvz4upmDHABudcoXOuCpgGjPZgXBGRqPD83I3sKaviZxf2bZT1eVHsm4FRZpZsZgacD6zyYFwRkSZvz/5K/vr5ei4c0IlBGWmNsk4v5tjnAW8Bi4DlwTGnhDquiEg0eOazdeyvrOausY2ztw4eXd3ROXc/cL8XY4mIRIutew/wwn82cuWQdPp0Smm09erMUxGRMHl05hoAfjq2T6OuV8UuIhIGK7eVMG1xPt8Z3Z2MNsmNum4Vu4hIGDw4PZfUpHh+eE6vRl+3il1ExGNz83bxrzWF3HZuL1onxzf6+lXsIiIeCgQc//fRKtLTWnDD6d18yaBiFxHx0PtLt5GzrYS7L+xDUnysLxlU7CIiHimvquHhGavp3yWVywen+5ZDxS4i4pFnP1/P1r0H+OXFpxATY77lULGLiHhgR3E5T326jnEDOjO6V3tfs6jYRUQ88OBHq6hxjvsuOsXvKCp2EZFQLdxUxLtLtvH9r51MZrvGPRmpLip2EZEQBAKO33ywkk6pib6cjFQXFbuISAjeXpTPsvxi7vl6P1omenJdxZCp2EVETlBpeRUPzVjN0Mw0Xw9vPJKKXUTkBD02K49d+yq4/9IBvh7eeCRPit3M0szsLTPLNbNVZna6F+OKiESqFVuL+dt/NnDdyEyGdG2cOyPVl1cTQo8D051zV5tZAuD/y8IiImESCDh++e4K2rZM4OcX9vM7zleEXOxmlgqcBdwE4JyrBCpDHVdEJFK9tmAzS7bs5dFrB/ty9cbj8WIqpgdQCLxgZovN7Fkza+nBuCIiEWfXvgomf5TLqB5tuXJo5Lxgejgvij0OGAY87ZwbCuwH7jlyITObaGbZZpZdWFjowWpFRBrf//5zFQeqavj9FadiFjkvmB7Oi2LPB/Kdc/OC779FbdH/F+fcFOdclnMuq0OHDh6sVkSkcX2xbjfTFm9l4lk96NWxld9xjirkYnfO7QC2mFnf4IfOB1aGOq6ISCQ5UFnDPdOWkdk2mdvO7e13nGPy6qiYHwOvBI+IWQ98x6NxRUQiwqOzVrNpdxmvfv80WiT4cwON+vKk2J1zS4AsL8YSEYk0izfv4bm5G7jutExG9/T3krz1oTNPRUSOoaK6hp+/tYxOqUnc+/XIO2a9LpFxxRoRkQj11Oy15BXs44WbRpCSFHnHrNdFe+wiIkexclsJf56zjm8MTefcfh39jlNvKnYRkTpUVge4+82lpCXH86tL+vsdp0E0FSMiUofHPl7Dyu0l/PXbWbRpmeB3nAbRHruIyBHmbyjimc/WMX5EVy7o38nvOA2mYhcROUxpeRU/fWMJXdskN7kpmIM0FSMicpjffLCSbXsP8OYtoyPmVncNpT12EZGg6Su289bCfH50bi+Gd2vjd5wTpmIXEQG2Fx/g3mnLOTW9NbefH9nXgjkeFbuINHvVNQFuf20xldUBHh8/hPjYpl2NTXMCSUTEQ3/8OI8FG/fw+Pgh9OgQuZfjra+m/WtJRCREn+cV8tSctXwzqyuXD4nMOyI1lIpdRJqtgpJy7py6hD4dU3jgsgF+x/GMil1EmqWagOOOqUsoq6zhyeuGRvw11htCc+wi0iz9YeZqvli/m4evHkTvTil+x/GUZ3vsZhZrZovN7B9ejSkiEg7/XLadp+es47rTMrkmq6vfcTzn5VTMHcAqD8cTEfHc6h2l/OytpQzLTOP+S5vmJQOOx5NiN7MM4GLgWS/GExEJh+KyKia+nE2rxDiemTCcxLjomVc/nFd77H8Efg4EPBpPRMRTNQHHHa8vZtveAzw9YRgdU5P8jhQ2IRe7mV0CFDjnFh5nuYlmlm1m2YWFhaGuVkSkQR6esZo5qwt54LIBDO/W1u84YeXFHvsZwGVmthGYCpxnZn8/ciHn3BTnXJZzLqtDhw4erFZEpH6mzt/MM5+t4/rTMrn+tG5+xwm7kIvdOXevcy7DOdcdGA/Mds5NCDmZiIgHPs8rZNK7Kzi7Twd+E0UnIR2LTlASkai1ZmcpP/z7Inp3bMWT1w0lrolf3Ku+PD1ByTk3B5jj5ZgiIieisLSC77ywgKSEWJ67aQQpSfF+R2o0zePXl4g0K/sqqrn5xQXs3l/BczdmkZ7Wwu9IjUqXFBCRqFJRXcMPXs4mZ1sJf5kwnEEZaX5HanTaYxeRqFETcNzx2hL+vXY3D101iDH9O/kdyRcqdhGJCs45Jr2znOk5O/jVJf25aniG35F8o2IXkagwefpqpi7Ywm3n9uLmM0/2O46vVOwi0uQ9NmvNoROQ7hrbx+84vlOxi0iT9seP1/D4J3lcMzyD310+EDPzO5LvVOwi0mQ9/nEef/w4j6uHZzD5qkHExKjUQcUuIk3UE5/k8djHa7hqmEr9SDqOXUSaFOccj8xcw5OfruUbw9J56OpBxKrU/4uKXUSajJqA49fvreCVeZsZP6Ir/3PlqSr1OqjYRaRJqKwO8NM3lvCPZdu55eye/GJcX71QehQqdhGJeGWV1dz690V8tqaQe77ej1vO7ul3pIimYheRiFZQWs73X1rI8vy9PPiNUxk/MtPvSBFPxS4iESt3Rwk3/y2bov2VPD1hOBcO6Ox3pCZBxS4iEWnO6gJue3UxyQmxvPGD0zk1o7XfkZoML25m3dXMPjWzVWaWY2Z3eBFMRJon5xwvfbGR7/5tAV3bJvPebWeo1BvIiz32auAu59wiM0sBFprZLOfcSg/GFpFmpLyqhknvrODtRfmc168jT3xrKK0SNbHQUCFvMefcdmB78HGpma0C0gEVu4jU25aiMn7w8kJWbi/h9vN7c8f5vXWM+gny9FehmXUHhgLz6nhuIjARIDNTr2qLyP83Z3UBd0xdgnOO527M4vxTmucNMrziWbGbWSvgbeBO51zJkc8756YAUwCysrKcV+sVkaarsjrAIzNXM+Xz9fTrnMozE4bRrV1Lv2M1eZ4Uu5nFU1vqrzjnpnkxpohEt3WF+7hj6mJWbC3h+tMy+eXF/WmREOt3rKgQcrFb7Tm9zwGrnHOPhh5JRKKZc46pC7bw2w9WkhQfw5QbhjNWx6d7yos99jOAG4DlZrYk+LH7nHMfejC2iESRrXsPMOmd5cxZXciZvdrzyLWD6ZSa5HesqOPFUTFzAb10LSJHFQg4Xpm/mQc/XEXAwf2X9ufG07vrGuphogNERSSs1hXu495py5m/oYgze7Xn/75xKl3bJvsdK6qp2EUkLPZVVPOn2Xk8P3cDLeJjeejqQVwzPEOX2m0EKnYR8ZRzjveWbON/P1xFQWkFVw/P4Bfj+tEhJdHvaM2Gil1EPDN/QxGTp+eycNMeBme05i83DGdoZhu/YzU7KnYRCVnOtmL+MGM1n64upGNKIpOvOpVrhnfVi6M+UbGLyAlbs7OUP81eywdLt5GaFMc9X+/Hjad314lGPlOxi0iDLdmylz9/upaZK3fSIj6WH57Tkx+c1ZPWyfF+RxNU7CJST4GA47M1hTw7dz3/Xrub1KQ4bj+/NzeN7k7blgl+x5PDqNhF5JiKy6p4c+EWXv5yE5t2l9ExJZH7LurHdad107XSI5S+KyLyFc45sjft4a3sfN5bupXyqgAjurfhrrF9GTegMwlxId98TcJIxS4ih2zavZ9pi7byzuKtbC4qIzkhliuGpPPt07vT/6RUv+NJPanYRZq5tQX7mJGzg5k5O1iaX4wZnNGzPXeO6c24gZ1JTlBNNDX6jok0M1U1AZZu2cunqwuYkbOTtQX7ABic0ZpfjOvHFUNPokvrFj6nlFCo2EWinHOO9bv2MzdvF5/n7eLL9bvZV1FNbIwxsntbbhjVjbEDOqnMo4iKXSTKlFVWs3RLMYs272Hx5j0s2ryXov2VAHRt24JLB5/E13q3Z3TPdqQl6zDFaOTVrfHGAY8DscCzzrkHvRhXRI7OOcf24nJyd5SQu6OU3O2l5O4oYV3hfmoCtbcV7tGhJef168iwzDac0aud7ifaTHhxa7xY4CngAiAfWGBm7zvnVoY6tkhzV1FdQ0FJBfl7DrC5aD+bdpfV/ivaz6ZdZZRWVB9aNj2tBad0SeHCAZ0ZltmGIV3TaKMTh5olL/bYRwJrnXPrAcxsKnA5oGIXCXLOUVEdoLyqhpID1RQfqKL4QBUl5VWHHu8tq6KwtIKC0nIKSirYWVrO3rKq/xonLsbIaNOCzHYtGdq1DX06taJfl1T6dEqhdQudzi+1vCj2dGDLYe/nA6d5MK40c4GAo6yqhn3l1ZSWV1FaUc2+8mr2VVSzv6KaiuoAldUBKmuCbw9/XBPAOUcgAAHncATfutqSDTgO+1jtxwMHP35omYOfx38tc/hbR+3nHHy/JuCoqK6hvKq2xMuraqioDlBRHTju1xsXY3RISaRjahKZ7ZIZcXIbOqYk0Sk1kS6tW9C9XUtOSksiLlYnB8mxeVHsdV2X031lIbOJwESAzMxMD1YrTVVVTYDte8vJ31tG/p4DFJZWUFhawe79lewqrWD3/gp27atkT1kl7is/SUcXY5AQF0NCbAwJcTHEmBFjhhmH3h56zOEfq30/NniJ2RgzYmLAMGIOPl/H58XEQIzF/Nc4MQZJcbEkxceQFB9LUnwsifExJB78WFwsqS3iad0intSkOFonH3wcT3JCrO4uJJ7wotjzga6HvZ8BbDtyIefcFGAKQFZWVgP+u0pTFAg4tu49QF5BKWsL9pG3cx8bd+9n654D7CgpJ3DET0BKYhztUxJp1zKBHu1bMaJ7Am1bJpCSFEerxPjat0lxpCTWvm2ZEEdiXG2BHyxz7cmK1PKi2BcAvc3sZGArMB64zoNxpYmoqgmwZmcpy/KLWZZfzIqtxawt2MeBqppDy7RvlUiP9i0Z1bMdGW2SyWjTovZfWjIdUxNJitf1u0W8EnKxO+eqzew2YAa1hzs+75zLCTmZRKyS8iqyNxbx5foiFmwsImdbCZXBOeTUpDhOzWjNt0Zm0rtTK3p3bEWvjq10vLRII/LkOHbn3IfAh16MJZGnsjpA9sYi5qwp5Mv1u1mxtZiAg/hYY3BGGt8e1Y1BXdMYlN6abu2SNU8s4jOdeSp12rWvgjmrC5mdu5PP1+yitKKahNgYhmSmcdt5vRl1cluGZrbRLdBEIpCKXQ7ZW1bJ9BU7+GDZNr5Yt5uAg44piVw8qAvn9evIGb3a01I3VhCJePpf2sxVVNcwM2cn7y7eyr/yCqmqcXRvl8yPzu3FhQM6M+CkVE2tiDQxKvZmam3BPqbO38y0xVsp2l9Jl9ZJ3DS6O5cNTmdguspcpClTsTcjNQHHzJwdvPCfjczfUERcjHFB/06MH5nJmb3aHzpBR0SaNhV7M1BWWc2b2fk8N3cDm4vK6Nq2Bb8Y14+rh2fQISXR73gi4jEVexTbW1bJc3M38NIXmyg+UMWwzDTu/Xo/xg7orL1zkSimYo9CxQeqeG7uBl6Yu4HSimouHNCJiWf1YHi3tn5HE5FGoGKPImWV1Tz7+Qb++vl6SsurGTegM3eM6c0pXXR3eZHmRMUeBQIBx9uL8nl4xmoKSiu4oH8n7hzTmwEntfY7moj4QMXexH2xbje//+dKcraVMKRrGk9PGM7wbm38jiUiPlKxN1EFpeX87h+r+GDpNtLTWvD4+CFcNvgkHX8uIir2piYQcLw6fzOTp+dSUR3gzjG9ueXsnrrsrYgcomJvQlbvKOWeactYvHkvo3u24/dXDKRHh1Z+xxKRCKNibwJqAo5nP1/PIzPX0CopjkevHcyVQ9M17SIidVKxR7hNu/dz95tLWbBxD+MGdOZ/rhxIu1Y6W1REji6kYjezh4FLgUpgHfAd59xeL4I1d845pi7Ywu/+sZLYGOOxbw7miiHaSxeR4wv17r+zgIHOuUHAGuDe0CPJvopqbp+6hHunLWdoZhoz7jyLK4dmqNRFpF5C2mN3zs087N0vgatDiyOrtpfwo1cWsXH3fn52YV9uPbsnMbqui4g0gJdz7N8FXvdwvGZn6vzN3P9+Dq1bxPPq90cxqkc7vyOJSBN03GI3s4+BznU8Nck5915wmUlANfDKMcaZCEwEyMzMPKGw0aqyOsBvPsjhlXmb+Vrv9jz2zSG01wukInKCjlvszrkxx3rezG4ELgHOd865Y4wzBZgCkJWVddTlmpui/ZXc+veFzNtQxK3n9OTusX11SV0RCUmoR8WMA34BnO2cK/MmUvORu6OE772YTUFpBX/85hCuGJrudyQRiQKhzrE/CSQCs4JHbHzpnLsl5FTNwOzcnfz41cW0SorjzR+czuCuaX5HEpEoEepRMb28CtKcvL5gM/e9s4L+XVJ59sYsOqUm+R1JRKKIzjxtRM45/jR7LY/OWsNZfTrw9PXDaJmob4GIeEut0khqAo5fvbeCV+dt5hvD0pl81SDiY0M9P0xE5KtU7I2gsjrA7a8tZnrODm49pyc/v7CvziIVkbBRsYdZeVUNP3xlEbNzC/jVJf25+cyT/Y4kIlFOxR5GByprmPhyNp/n7eL3VwxkwqhufkcSkWZAxR4m+yuqufnFBczbUMRDVw/i2qyufkcSkWZCxR4GZZXV3PTCfBZu2sNj1+rEIxFpXCp2j5VX1fD9l7JZuGkPT3xrKJcMOsnvSCLSzKjYPVRVE+BHryzi32t388g1g1XqIuILHUjtkZqA487Xl/BJbgG/u2IgVw3P8DuSiDRTKnYPBAKOe95exj+Xbee+i/pxg45+EREfqdg9MHlGLm8uzOf283sz8ayefscRkWZOxR6iF/+zkb98tp4JozL5yZjefscREVGxh2L6ih088EEOY07pxG8uG6jLBIhIRFCxn6CFm4q4Y+piBmek8advDdVdj0QkYqjYT8D6wn3c/GI2XVon8dyNWbRIiPU7kojIIZ4Uu5ndbWbOzNp7MV4kKy6r4nsvZhNjxovfHUk73XRaRCJMyMVuZl2BC4DNoceJbNU1AW57bRFb9pTxzIThdGvX0u9IIiJf4cUe+2PAzwHnwVgR7X8/zOXzvF387vKBjDy5rd9xRETqFFKxm9llwFbn3NJ6LDvRzLLNLLuwsDCU1frijQVbeP7fG7hpdHfGj8z0O46IyFEd91oxZvYx0LmOpyYB9wFj67Mi59wUYApAVlZWk9q7z95YxKR3l3Nmr/b88uJT/I4jInJMxy1259yYuj5uZqcCJwNLg8dvZwCLzGykc26Hpyl9VFBazq2vLCI9rQVPXjeUON2nVEQi3Alf3dE5txzoePB9M9sIZDnndnmQKyJU1wT48auLKS2v4uWbR5KWnOB3JBGR49Jle4/hkVlrmLehiEeuGUy/zql+xxERqRfPit05192rsSLBrJU7eXrOOr41MlOX4BWRJkUTxnXYvLuMu95YwsD0VO6/tL/fcUREGkTFfoSK6hp++OpCAJ6+fjhJ8bpcgIg0LZpjP8LD01ezYmsJU24YTte2yX7HERFpMO2xH+Zfawp5du4GbhjVjbED6jp0X0Qk8qnYg3bvq+CuN5fSu2MrJukkJBFpwjQVAzjn+Plbyyg+UMVL3x2peXURadK0xw78/ctNfJJbwL1f78cpXXS8uog0bc2+2PN2lvL7f67inL4duGl0d7/jiIiErFkXe3VNgLveXErLxDgevnqw7lkqIlGhWc+x/+Vf61mWX8xT1w2jQ4ruhCQi0aHZ7rHn7ijhjx+v4eJBXbh4UBe/44iIeKZZFntVTYC73lhK6xbx/O7ygX7HERHxVLOcivnzp+vI2VbCMxOG07alLsUrItGl2e2x52wr5k+z87h8yEmMG6izS0Uk+jSrYq+uCXDP28tJS07ggUsH+B1HRCQsmtVUzN/+s5HlW4t58rqhtNEUjIhEqZD32M3sx2a22sxyzOwhL0KFQ/6eMh6ZuYbz+nXk4lN1FIyIRK+Q9tjN7FzgcmCQc67CzDoe73P84Jzj1+/lAPDbywfoRCQRiWqh7rHfCjzonKsAcM4VhB7Je/9cvp3ZuQXcNbYPGW10jXURiW6hFnsf4GtmNs/MPjOzEUdb0Mwmmlm2mWUXFhaGuNr6Ky6r4oH3VzIwPVXXghGRZuG4UzFm9jFQ13GBk4Kf3wYYBYwA3jCzHs45d+TCzrkpwBSArKysrzwfLpNn5FK0v4K/fWcEcbHN6iAgEWmmjlvszrkxR3vOzG4FpgWLfL6ZBYD2QOPtkh/D0i17eW3+Zr4z+mQGprf2O46ISKMIdRf2XeA8ADPrAyQAu0IN5YVAwPHr93No1zKRn1zQ2+84IiKNJtTj2J8HnjezFUAlcGNd0zB+eGtRPku37OXRaweTkhTvdxwRkUYTUrE75yqBCR5l8UzxgSomf5TL8G5tuHJout9xREQaVVSeefrYrDUUlVXy4mUjdcy6iDQ7UXeYyKrtJbz0xUauPy1TL5iKSLMUVcXunOOB93No3SKeu8f29TuOiIgvoqrYp6/YwbwNRdx9YV/SknWRLxFpnqKm2Cuqa3hwei59O6UwfkSm33FERHwTNcX+8heb2LS7jPsuPoXYGL1gKiLNV1QU+579lTzxSR5n9enA2X06+B1HRMRXUVHsT8zOY19FNZMuOsXvKCIivmvyxb6+cB8vf7GJb47oSt/OKX7HERHxXZMv9gc/yiUxLoafXNDH7ygiIhGhSRf7/A1FzFy5k1vP6UnHlCS/44iIRIQmW+zOOSZPz6VjSiI3n9nD7zgiIhGjyRb77NwCFm7awx1jetMiIdbvOCIiEaNJFnsg4Hh4xmq6t0vm2qyufscREYkoTbLYP1i2jdwdpfzkgj7E63Z3IiL/JaRWNLMhZvalmS0J3qh6pFfBjqaqJsCjs9ZwSpdULh10UrhXJyLS5IS6u/sQ8Bvn3BDg18H3w+r1BVvYtLuMn13YhxhdOkBE5CtCLXYHpAYftwa2hTjeMR2orOGJT/IY0b0N5/btGM5ViYg0WaHeQelOYIaZ/YHaXxKjQ490dC9+sZGC0gqeun6Y7owkInIUxy12M/sY6FzHU5OA84GfOOfeNrNrgeeAMUcZZyIwESAz88Quq9u+VSLXZmUwonvbE/p8EZHmwJxzJ/7JZsVAmnPOWe0udLFzLvV4n5eVleWys7NPeL0iIs2RmS10zmUdb7lQ59i3AWcHH58H5IU4noiIhCjUOfbvA4+bWRxQTnCqRURE/BNSsTvn5gLDPcoiIiIe0GmbIiJRRsUuIhJlVOwiIlFGxS4iEmVU7CIiUSakE5ROeKVmhcCmE/z09sAuD+N4RbkaRrkaRrkaJlJzQWjZujnnOhxvIV+KPRRmll2fM68am3I1jHI1jHI1TKTmgsbJpqkYEZEoo2IXEYkyTbHYp/gd4CiUq2GUq2GUq2EiNRc0QrYmN8cuIiLH1hT32EVE5BgivtjN7GEzyzWzZWb2jpmlHWW5cWa22szWmtk9jZDrGjPLMbOAmR31FW4z22hmyw/e8DuCcjX29mprZrPMLC/4ts1RlqsJbqslZvZ+GPMc8+s3s0Qzez34/Dwz6x6uLA3MdZOZFR62jb7XSLmeN7MCM1txlOfNzJ4I5l5mZsMiJNc5ZlZ82Pb6dSNk6mpmn5rZquD/xTvqWCa828s5F9H/gLFAXPDxZGByHcvEAuuAHkACsBToH+ZcpwB9gTlA1jGW2wi0b8TtddxcPm2vh4B7go/vqev7GHxuXyNso+N+/cAPgWeCj8cDr0dIrpuAJxvr5+mw9Z4FDANWHOX5i4CPAANGAfMiJNc5wD8aeVt1AYYFH6cAa+r4PoZ1e0X8HrtzbqZzrjr47pdARh2LjQTWOufWO+cqganA5WHOtco5tzqc6zgR9czV6NsrOP6LwccvAleEeX3HUp+v//C8bwHnW/hvtOvH96VenHP/AoqOscjlwEuu1pdAmpl1iYBcjc45t905tyj4uBRYBaQfsVhYt1fEF/sRvkvtb7kjpQNbDns/n69uSL84YKaZLQze9zUS+LG9OjnntkPtDz7Q8SjLJZlZtpl9aWbhKv/6fP2HlgnuWBQD7cKUpyG5AK4K/vn+lpl1DXOm+ork/4Onm9lSM/vIzAY05oqDU3hDgXlHPBXW7RXqHZQ8cawbZjvn3gsuMwmoBl6pa4g6Phby4T71yVUPZzjntplZR2CWmeUG9zL8zNXo26sBw2QGt1cPYLaZLXfOrQs12xHq8/WHZRsdR33W+QHwmnOuwsxuofavivPCnKs+/Nhe9bGI2tPw95nZRcC7QO/GWLGZtQLeBu50zpUc+XQdn+LZ9oqIYnfOjTnW82Z2I3AJcL4LTlAdIR84fM8lg9r7sYY1Vz3H2BZ8W2Bm71D753ZIxe5BrkbfXma208y6OOe2B//kLDjKGAe313ozm0Pt3o7XxV6fr//gMvlWe+vH1oT/T/7j5nLO7T7s3b9S+7pTJAjLz1SoDi9U59yHZvZnM2uaerMWAAABjElEQVTvnAvrdWTMLJ7aUn/FOTetjkXCur0ifirGzMYBvwAuc86VHWWxBUBvMzvZzBKofbErbEdU1JeZtTSzlIOPqX0huM5X7xuZH9vrfeDG4OMbga/8ZWFmbcwsMfi4PXAGsDIMWerz9R+e92pg9lF2Kho11xHzsJdRO38bCd4Hvh082mMUUHxw6s1PZtb54GsjZjaS2s7bfezPCnmdBjwHrHLOPXqUxcK7vRrz1eITfIV5LbVzUUuC/w4eqXAS8OERrzKvoXbvblIj5LqS2t+6FcBOYMaRuag9umFp8F9OpOTyaXu1Az4B8oJv2wY/ngU8G3w8Glge3F7LgZvDmOcrXz/wW2p3IACSgDeDP3/zgR7h3kb1zPV/wZ+lpcCnQL9GyvUasB2oCv583QzcAtwSfN6Ap4K5l3OMI8UaOddth22vL4HRjZDpTGqnVZYd1lsXNeb20pmnIiJRJuKnYkREpGFU7CIiUUbFLiISZVTsIiJRRsUuIhJlVOwiIlFGxS4iEmVU7CIiUeb/AbRzuQGggFlvAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "x = numpy.linspace(-2,2,1000)\n",
     "y = x**3\n",
     "fig, ax = plt.subplots()\n",
     "ax.plot(x,y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is another plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(-np.pi, np.pi, 201)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(x,np.sin(x))"
    ]
   }
  ],
@@ -113,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@
 #| Code by default will be put into code cells
 #|
 #| * To make a markdown cell, prefix the comment line with with '#|' or '# |'
-#| * To split a code cell, add a line beginning with '#-' or '# -#
+#| * To split a code cell, add a line beginning with '#-' or '# -'
 
 import matplotlib.pyplot as plt
 import numpy

--- a/example.py
+++ b/example.py
@@ -4,17 +4,20 @@
 #|
 #| Code by default will be put into code cells
 #|
-#| * To make a markdown cell, prefix the comment line with with '#|'
-#| * To split a code cell, add a line beginning with '#-'
+#| * To make a markdown cell, prefix the comment line with with '#|' or '# |'
+#| * To split a code cell, add a line beginning with '#-' or '# -#
 
-import numpy
 import matplotlib.pyplot as plt
+import numpy
+
 %matplotlib inline
 
 #| Here is a markdown cell.
 #| Maths is also possible: $A=B$
 #|
-#| There are code cells below, split by '#-':
+#| There are code cells below, split by `'#-'`:
+
+# | Here is another markdown cell
 
 x = numpy.random.rand(5)
 
@@ -30,3 +33,10 @@ y = x**3
 fig, ax = plt.subplots()
 ax.plot(x,y)
 
+# -------------------------------
+
+# | Here is another plot
+
+x = np.linspace(-np.pi, np.pi, 201)
+fig, ax = plt.subplots()
+ax.plot(x,np.sin(x))

--- a/py2nb
+++ b/py2nb
@@ -8,9 +8,9 @@ import os
 
 import nbformat.v4
 
-CODE_SPLIT_CHARS = ['#-', '# -']
+ACCEPTED_CHARS = ['#-', '# -']
 MARKDOWN_CHARS = ['#|', '# |']
-
+ACCEPTED_CHARS.extend(MARKDOWN_CHARS)
 
 def new_cell(nb, cell, markdown=False):
     """ Create a new cell
@@ -35,6 +35,11 @@ def new_cell(nb, cell, markdown=False):
         nb.cells.append(cell)
     return ''
 
+def str_starts_with(string, options):
+    for opt in options:
+        if string.startswith(opt):
+            return True
+
 
 def convert(script_name):
     """ Convert the python script to jupyter notebook"""
@@ -43,9 +48,9 @@ def convert(script_name):
         code_cell = ''
         nb = nbformat.v4.new_notebook()
         for line in f:
-            if line.startswith((*CODE_SPLIT_CHARS, *MARKDOWN_CHARS)):
+            if str_starts_with(line, ACCEPTED_CHARS):
                 code_cell = new_cell(nb, code_cell)
-                if line.startswith((*MARKDOWN_CHARS, )):
+                if str_starts_with(line, MARKDOWN_CHARS):
                     # find the first occurence of |
                     # and add the rest of the line to the markdown cell
                     markdown_cell += line[line.index('|') + 1:]

--- a/py2nb
+++ b/py2nb
@@ -3,9 +3,14 @@
 
 Run as:  python to_noteebook.py my_script.py
 """
-import os
-import nbformat.v4
 import argparse
+import os
+
+import nbformat.v4
+
+CODE_SPLIT_CHARS = ['#-', '# -']
+MARKDOWN_CHARS = ['#|', '# |']
+
 
 def new_cell(nb, cell, markdown=False):
     """ Create a new cell
@@ -38,10 +43,12 @@ def convert(script_name):
         code_cell = ''
         nb = nbformat.v4.new_notebook()
         for line in f:
-            if line[:2] == '#-' or line[:2] == '#|':
+            if line.startswith((*CODE_SPLIT_CHARS, *MARKDOWN_CHARS)):
                 code_cell = new_cell(nb, code_cell)
-                if line[:2] == '#|':
-                    markdown_cell += line[2:]
+                if line.startswith((*MARKDOWN_CHARS, )):
+                    # find the first occurence of |
+                    # and add the rest of the line to the markdown cell
+                    markdown_cell += line[line.index('|') + 1:]
                 else:
                     markdown_cell = new_cell(nb, markdown_cell, markdown=True)
             else:
@@ -59,8 +66,10 @@ def parse_args():
     """Argument parsing for py2nb"""
     description = "Convert a python script to a jupyter notebook"
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("script_name", help="name of script (.py) to convert to jupyter notebook (.ipynb)")
-    return parser.parse_args() 
+    parser.add_argument(
+        "script_name",
+        help="name of script (.py) to convert to jupyter notebook (.ipynb)")
+    return parser.parse_args()
 
 
 def main():


### PR DESCRIPTION
Use `startswith` instead of a string index.

Changes how the markdown text is found so that it works for both syntaxes.

Some of the other changes are just formatting and import sorting.