### PR TITLE
Fix command block exclamation mark rendering and add executed example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ py2nb: convert python scripts to jupyter notebooks
 ==================================================
 :py2nb: convert python scripts to jupyter notebooks
 :Author: Will Handley
-:Version: 1.1.0
+:Version: 1.1.1
 :Homepage: https://github.com/williamjameshandley/py2nb
 
 .. image:: https://badge.fury.io/py/py2nb.svg

--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,14 @@ then running
 
 produces the notebook `example.ipynb <https://github.com/williamjameshandley/py2nb/blob/master/example.ipynb>`_
 
+To see an executed version with outputs and plots, run:
+
+.. code :: bash
+
+   py2nb example.py --execute --output example_executed
+
+which produces `example_executed.ipynb <https://github.com/williamjameshandley/py2nb/blob/master/example_executed.ipynb>`_ with all code cells executed and outputs displayed.
+
 Command Line Options
 ====================
 

--- a/example.ipynb
+++ b/example.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "pip install matplotlib numpy"
+    "!pip install matplotlib numpy"
    ]
   },
   {

--- a/example_executed.ipynb
+++ b/example_executed.ipynb
@@ -21,10 +21,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2025-05-30T11:09:39.572319Z",
-     "iopub.status.busy": "2025-05-30T11:09:39.571966Z",
-     "iopub.status.idle": "2025-05-30T11:09:39.949199Z",
-     "shell.execute_reply": "2025-05-30T11:09:39.948214Z"
+     "iopub.execute_input": "2025-06-01T08:09:04.817404Z",
+     "iopub.status.busy": "2025-06-01T08:09:04.817167Z",
+     "iopub.status.idle": "2025-06-01T08:09:05.460049Z",
+     "shell.execute_reply": "2025-06-01T08:09:05.459333Z"
     },
     "tags": [
      "command"
@@ -54,17 +54,10 @@
       "\u001b[1;35mnote\u001b[0m: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.\r\n",
       "\u001b[1;36mhint\u001b[0m: See PEP 668 for the detailed specification.\r\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
     }
    ],
    "source": [
-    "pip install matplotlib numpy"
+    "!pip install matplotlib numpy"
    ]
   },
   {
@@ -72,10 +65,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-05-30T11:09:39.953185Z",
-     "iopub.status.busy": "2025-05-30T11:09:39.952779Z",
-     "iopub.status.idle": "2025-05-30T11:09:40.235274Z",
-     "shell.execute_reply": "2025-05-30T11:09:40.234956Z"
+     "iopub.execute_input": "2025-06-01T08:09:05.462524Z",
+     "iopub.status.busy": "2025-06-01T08:09:05.462265Z",
+     "iopub.status.idle": "2025-06-01T08:09:05.960092Z",
+     "shell.execute_reply": "2025-06-01T08:09:05.959641Z"
     }
    },
    "outputs": [],
@@ -108,10 +101,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-05-30T11:09:40.237226Z",
-     "iopub.status.busy": "2025-05-30T11:09:40.237033Z",
-     "iopub.status.idle": "2025-05-30T11:09:40.242553Z",
-     "shell.execute_reply": "2025-05-30T11:09:40.242188Z"
+     "iopub.execute_input": "2025-06-01T08:09:05.962204Z",
+     "iopub.status.busy": "2025-06-01T08:09:05.961965Z",
+     "iopub.status.idle": "2025-06-01T08:09:05.971460Z",
+     "shell.execute_reply": "2025-06-01T08:09:05.970968Z"
     }
    },
    "outputs": [],
@@ -124,10 +117,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-05-30T11:09:40.244697Z",
-     "iopub.status.busy": "2025-05-30T11:09:40.244364Z",
-     "iopub.status.idle": "2025-05-30T11:09:40.246650Z",
-     "shell.execute_reply": "2025-05-30T11:09:40.246321Z"
+     "iopub.execute_input": "2025-06-01T08:09:05.973565Z",
+     "iopub.status.busy": "2025-06-01T08:09:05.973225Z",
+     "iopub.status.idle": "2025-06-01T08:09:05.976101Z",
+     "shell.execute_reply": "2025-06-01T08:09:05.975692Z"
     }
    },
    "outputs": [],
@@ -148,17 +141,17 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-05-30T11:09:40.248128Z",
-     "iopub.status.busy": "2025-05-30T11:09:40.247994Z",
-     "iopub.status.idle": "2025-05-30T11:09:40.348901Z",
-     "shell.execute_reply": "2025-05-30T11:09:40.348573Z"
+     "iopub.execute_input": "2025-06-01T08:09:05.977981Z",
+     "iopub.status.busy": "2025-06-01T08:09:05.977809Z",
+     "iopub.status.idle": "2025-06-01T08:09:06.105804Z",
+     "shell.execute_reply": "2025-06-01T08:09:06.105293Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x761c3a880410>]"
+       "[<matplotlib.lines.Line2D at 0x78748c5ac550>]"
       ]
      },
      "execution_count": 5,
@@ -195,17 +188,17 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-05-30T11:09:40.350478Z",
-     "iopub.status.busy": "2025-05-30T11:09:40.350326Z",
-     "iopub.status.idle": "2025-05-30T11:09:40.439581Z",
-     "shell.execute_reply": "2025-05-30T11:09:40.439285Z"
+     "iopub.execute_input": "2025-06-01T08:09:06.107630Z",
+     "iopub.status.busy": "2025-06-01T08:09:06.107279Z",
+     "iopub.status.idle": "2025-06-01T08:09:06.210915Z",
+     "shell.execute_reply": "2025-06-01T08:09:06.210228Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x761c3a49f250>]"
+       "[<matplotlib.lines.Line2D at 0x787483fa7390>]"
       ]
      },
      "execution_count": 6,

--- a/nb2py.py
+++ b/nb2py.py
@@ -42,7 +42,11 @@ def convert(notebook_name, output_name=None):
                         # Check if this is a command cell
                         is_command_cell = 'command' in cell.get('metadata', {}).get('tags', [])
                         if is_command_cell:
-                            line = '#! ' + line.lstrip()
+                            # Remove leading ! if present (from py2nb conversion)
+                            stripped_line = line.lstrip()
+                            if stripped_line.startswith('!'):
+                                stripped_line = stripped_line[1:].lstrip()
+                            line = '#! ' + stripped_line
                     line = line.rstrip() + '\n'
                     f_out.write(line)
                 f_out.write('\n')

--- a/py2nb.py
+++ b/py2nb.py
@@ -90,8 +90,8 @@ def get_comment_type(line):
 def extract_content(line, comment_type):
     """Extract content from comment line based on type."""
     if comment_type == 'command':
-        # Find first ! and return everything after it
-        return line[line.index('!') + 1:].lstrip()
+        # Find first ! and return ! plus everything after it
+        return '!' + line[line.index('!') + 1:].lstrip()
     elif comment_type == 'markdown':
         # Find first | and return everything after it  
         return line[line.index('|') + 1:]

--- a/test_py2nb.py
+++ b/test_py2nb.py
@@ -97,7 +97,7 @@ import matplotlib.pyplot as plt"""
         # Check command cell has command tag
         command_cell = nb['cells'][1]
         self.assertIn('command', command_cell.get('metadata', {}).get('tags', []))
-        self.assertIn('pip install numpy', ''.join(command_cell['source']))
+        self.assertIn('!pip install numpy', ''.join(command_cell['source']))
 
     def test_cell_splits(self):
         """Test code cell splitting with #- syntax."""

--- a/test_py2nb.py
+++ b/test_py2nb.py
@@ -213,7 +213,7 @@ plt.plot(x)"""
     def test_content_extraction(self):
         """Test content extraction from comment lines."""
         self.assertEqual(py2nb.extract_content('#| markdown text', 'markdown'), ' markdown text')
-        self.assertEqual(py2nb.extract_content('#! pip install numpy', 'command'), 'pip install numpy')
+        self.assertEqual(py2nb.extract_content('#! pip install numpy', 'command'), '!pip install numpy')
         self.assertEqual(py2nb.extract_content('# | spaced markdown', 'markdown'), ' spaced markdown')
 
     def test_file_not_found(self):


### PR DESCRIPTION
## Summary
- Fixes command block `#\!` syntax to properly render as `\!command` instead of `command`
- Adds `example_executed.ipynb` demonstrating the `--execute` option
- Updates README with documentation for executed examples

## Test plan
- [x] Verified fix resolves the reported issue with `#\! pip install blackjax` 
- [x] Updated and ran test suite to ensure all tests pass
- [x] Generated executed example notebook with plots and outputs
- [x] Updated README documentation

🤖 Generated with [Claude Code](https://claude.ai/code)