### PR TITLE
Add --version flag to py2nb and nb2py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ py2nb: convert python scripts to jupyter notebooks
 ==================================================
 :py2nb: convert python scripts to jupyter notebooks
 :Author: Will Handley
-:Version: 1.1.1
+:Version: 1.2.0
 :Homepage: https://github.com/williamjameshandley/py2nb
 
 .. image:: https://badge.fury.io/py/py2nb.svg
@@ -145,9 +145,11 @@ Command Line Options
    py2nb script.py --execute            # Convert and execute notebook
    py2nb script.py --output workshop    # Custom output name
    py2nb script.py --output workshop --execute  # Custom name + execution
+   py2nb --version                      # Show version number
 
    nb2py notebook.ipynb                 # Convert notebook to script
    nb2py notebook.ipynb --output script # Custom output script name
+   nb2py --version                      # Show version number
 
 Command Blocks
 ==============

--- a/nb2py.py
+++ b/nb2py.py
@@ -15,6 +15,18 @@ import json
 # Export main functions for module use
 __all__ = ['convert']
 
+def get_version():
+    """Get version from README.rst file."""
+    try:
+        readme_path = os.path.join(os.path.dirname(__file__), 'README.rst')
+        with open(readme_path, 'r') as f:
+            for line in f:
+                if ':Version:' in line:
+                    return line.split(':')[2].strip()
+    except (FileNotFoundError, IndexError):
+        pass
+    return "unknown"
+
 
 def convert(notebook_name, output_name=None):
     """ Convert the jupyter notebook to python script"""
@@ -59,15 +71,24 @@ def parse_args():
     """Argument parsing for nb2py"""
     description = "Convert a jupyter notebook to a python script"
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("notebook_name", help="name of notebok (.ipynb) to convert to script (.py)")
+    parser.add_argument("notebook_name", nargs='?', help="name of notebok (.ipynb) to convert to script (.py)")
     parser.add_argument(
         "--output", 
         help="specify output script filename (default: notebook_name.py)")
+    parser.add_argument(
+        "--version", 
+        action="version",
+        version=f"nb2py {get_version()}")
     return parser.parse_args() 
 
 
 def main():
     args = parse_args()
+    
+    if args.notebook_name is None:
+        print("Error: notebook_name is required")
+        return 1
+    
     script_name = convert(args.notebook_name, output_name=args.output)
     print(f"✓ Successfully converted {args.notebook_name} to {script_name}")
     return script_name

--- a/py2nb.py
+++ b/py2nb.py
@@ -19,6 +19,18 @@ import nbformat.v4
 # Export main functions for module use
 __all__ = ['convert', 'execute_notebook', 'validate_notebook', 'CELL_SPLIT_CHARS', 'MARKDOWN_CHARS', 'COMMAND_CHARS']
 
+def get_version():
+    """Get version from README.rst file."""
+    try:
+        readme_path = os.path.join(os.path.dirname(__file__), 'README.rst')
+        with open(readme_path, 'r') as f:
+            for line in f:
+                if ':Version:' in line:
+                    return line.split(':')[2].strip()
+    except (FileNotFoundError, IndexError):
+        pass
+    return "unknown"
+
 # Comment syntax patterns
 CELL_SPLIT_CHARS = ['#-', '# -']
 MARKDOWN_CHARS = ['#|', '# |']
@@ -262,6 +274,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "script_name",
+        nargs='?',
         help="name of script (.py) to convert to jupyter notebook (.ipynb)")
     parser.add_argument(
         "--no-validate", 
@@ -274,12 +287,20 @@ def parse_args():
     parser.add_argument(
         "--output", 
         help="specify output notebook filename (default: script_name.ipynb)")
+    parser.add_argument(
+        "--version", 
+        action="version",
+        version=f"py2nb {get_version()}")
     return parser.parse_args()
 
 
 def main():
     """Main conversion function."""
     args = parse_args()
+    
+    if args.script_name is None:
+        print("Error: script_name is required")
+        return 1
     
     if not os.path.exists(args.script_name):
         print(f"Error: File {args.script_name} not found")


### PR DESCRIPTION
## Summary
- Adds `--version` flag to both `py2nb` and `nb2py` command-line tools
- Implements `get_version()` function that reads version from README.rst
- Updates argument parsing to handle optional script_name when using `--version`
- Updates README documentation with new command-line options
- Bumps version to 1.2.0 for new feature

## Test plan
- [x] Verified `py2nb --version` and `nb2py --version` work correctly
- [x] Confirmed normal conversion functionality still works
- [x] All 16 tests pass
- [x] Help text shows new --version option
- [x] Round-trip conversion (py2nb -> nb2py -> py2nb) works correctly

## Usage
```bash
py2nb --version          # Shows: py2nb 1.2.0
nb2py --version          # Shows: nb2py 1.2.0
```

This addresses the common need for users to check which version of py2nb they have installed, especially useful for debugging and ensuring compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)